### PR TITLE
chore: Update docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## Running Author Tools service
 
 ```
-docker-compose up --build -d
+docker compose up --build -d
 ```
 
 ## Testing Web UI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.3'
 services:
   author-tools:
     build: .


### PR DESCRIPTION
* `docker-compose` command is renamed as `docker compose`.
* `version` in `docker-compose.yml` file is obsolete now.