### PR TITLE
fix: Handle non-UTF-8 characters in ABNF parser stderr output

### DIFF
--- a/at/utils/abnf.py
+++ b/at/utils/abnf.py
@@ -15,7 +15,7 @@ def extract_abnf(filename, logger=getLogger()):
     result = ""
 
     if output and output.stderr:
-        error = output.stderr.decode("utf-8")
+        error = output.stderr.decode("utf-8", errors="ignore")
         result += error
         logger.info("bap aex error: {}".format(error))
 
@@ -42,7 +42,7 @@ def parse_abnf(filename, logger=getLogger()):
     abnf = ""
 
     if output and output.stderr:
-        errors = output.stderr.decode("utf-8").replace(filename, "")
+        errors = output.stderr.decode("utf-8", errors="ignore").replace(filename, "")
 
     if output and output.stdout:
         abnf = output.stdout.decode("utf-8", errors="ignore")


### PR DESCRIPTION
## Summary
Add `errors="ignore"` parameter to `stderr.decode()` calls in the ABNF parser to prevent crashes when BAP tool outputs non-UTF-8 characters.

## Changes
- Modified `at/utils/abnf.py`:
  - Line 18: Added `errors="ignore"` to stderr decode in `extract_abnf()`
  - Line 45: Added `errors="ignore"` to stderr decode in `parse_abnf()`

## Problem
The application was crashing with `UnicodeDecodeError` when the BAP (ABNF parser) tool output non-UTF-8 characters in stderr. The stdout decode calls already had `errors="ignore"` error handling, but stderr decode calls did not.

Example errors:
- `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 2298`
- `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 0`

## Solution
Made stderr decoding consistent with stdout decoding by adding the `errors="ignore"` parameter. This allows the decoder to skip or replace invalid UTF-8 sequences instead of raising an exception.

## Testing
- [x] Python syntax validation passed
- [x] All decode calls now consistently use `errors="ignore"`

## Related Issues
- Fixes #284 
- Fixes #530 
