### PR TITLE
fix: Ensure ABNF input files end with a newline

### DIFF
--- a/at/api.py
+++ b/at/api.py
@@ -496,6 +496,8 @@ def abnf_parse():
     logger = current_app.logger
 
     input = request.values.get("input", "")
+    if input and not input.endswith("\n"):
+        input += "\n"
     _, filename = save_file_from_text(input, current_app.config["UPLOAD_DIR"])
 
     errors, abnf = parse_abnf(filename, logger=logger)

--- a/at/utils/file.py
+++ b/at/utils/file.py
@@ -86,6 +86,8 @@ def save_file_from_text(text, upload_dir):
 
     with open(filename, "w") as file:
         file.write(text)
+        if text and not text.endswith("\n"):
+            file.write("\n")
 
     return (dir_path, filename)
 

--- a/at/utils/file.py
+++ b/at/utils/file.py
@@ -86,8 +86,6 @@ def save_file_from_text(text, upload_dir):
 
     with open(filename, "w") as file:
         file.write(text)
-        if text and not text.endswith("\n"):
-            file.write("\n")
 
     return (dir_path, filename)
 


### PR DESCRIPTION
## Summary
Ensure ABNF input ends with a trailing newline so the BAP parser doesn't fail.

## Problem
When users paste ABNF input without a trailing newline, BAP fails with:
```
(103:21): error: state 54, token "end of file": syntax error
```

## Fix
Added a newline check in the `abnf_parse()` endpoint before saving the input:
```python
if input and not input.endswith("\n"):
    input += "\n"
```

The newline handling is scoped to the ABNF parse endpoint (`/api/abnf/parse`) rather than the general-purpose `save_file_from_text()` utility, which preserves its round-trip contract for other callers.

## Testing
- All 221 tests pass, including the Hypothesis-based `test_save_file_from_text`

Fixes #441