### PR TITLE
fix: Preserve download button when running validation

### DIFF
--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -36,17 +36,19 @@ for (let button of renderButtons) {
   button.addEventListener("click", render);
 }
 
-function reset() {
+function reset(keepDownload) {
   for (let tooltip of tooltipList) {
     tooltip.hide();
   }
 
   alertError.style.display = 'none';
-  buttonDownload.style.display = 'none';
-  buttonDownload.setAttribute('download', '');
-  buttonDownload.href = '#';
-  buttonOpen.style.display = 'none';
-  buttonOpen.href = '#';
+  if (!keepDownload) {
+    buttonDownload.style.display = 'none';
+    buttonDownload.setAttribute('download', '');
+    buttonDownload.href = '#';
+    buttonOpen.style.display = 'none';
+    buttonOpen.href = '#';
+  }
   messageError.innerHTML = '';
   accordionValidation.style.display = 'none';
   accordionItemWarnings.style.display = 'none';
@@ -149,7 +151,7 @@ function render(event) {
 }
 
 function validate() {
-  reset();
+  reset(true);
 
   buttonValidate.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>' + buttonValidate.innerHTML;
   disableButtons();


### PR DESCRIPTION
## Summary
- Prevent the validate action from clearing the download/open buttons when a rendered document is already available
- Users can now render a document, then validate it without losing their download link

## Changes
- Added a `keepDownload` parameter to the `reset()` function in `main.js`
- When `validate()` calls `reset(true)`, the download and open buttons are preserved
- All other callers (e.g. `render()`) continue to call `reset()` without arguments, clearing buttons as before

## Testing
- All 221 tests pass locally in Docker

Fixes #468 