### PR TITLE
fix: Handle non-UTF-8 markdown files in md2xml

### DIFF
--- a/at/utils/processor.py
+++ b/at/utils/processor.py
@@ -39,10 +39,10 @@ def process_file(file, upload_dir, logger=getLogger()):
 
 def md2xml(filename, logger=getLogger()):
     """Calls correct markdown processor for markdown files"""
-    with open(filename, "r") as file:
+    with open(filename, "rb") as file:
         first_line = file.readline().strip()
 
-    if len(first_line) > 2 and first_line[:3] == "%%%":
+    if len(first_line) > 2 and first_line[:3] == b"%%%":
         return mmark2xml(filename, logger)
     else:
         return kramdown2xml(filename, logger)


### PR DESCRIPTION
## Summary
- Fix `UnicodeDecodeError` when processing markdown files containing non-UTF-8 bytes

## Problem
`md2xml()` opens files in text mode (`"r"`) to check if the first line starts with `%%%` (mmark format). Files with non-UTF-8 bytes (e.g. `0x96`) crash with:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 0: invalid start byte
```

## Fix
Open the file in binary mode (`"rb"`) and compare against `b"%%%"`. The function only needs to check a 3-byte prefix, so full UTF-8 decoding is unnecessary.

## Testing
- All 221 tests pass locally in Docker

Fixes #471